### PR TITLE
Fix signup success page mobile overflow and button navigation

### DIFF
--- a/src/pages/SignupSuccessPage.jsx
+++ b/src/pages/SignupSuccessPage.jsx
@@ -1,7 +1,7 @@
 import { motion, AnimatePresence } from 'framer-motion'
 import { useEffect, useState } from 'react'
-// === 1. useNavigate import 제거 ===
-// import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
+import '../styles/pages/SignupSuccess.css'
 
 // --- 인라인 SVG 아이콘 ---
 
@@ -57,10 +57,10 @@ const iconVariants = {
 
 // 종이 비행기 비행 모션
 const sendingVariants = {
-    hidden: { opacity: 0, x: -100, rotate: -15 },
+    hidden: { opacity: 0, x: '-60%', rotate: -15 },
     visible: {
         opacity: [0, 1, 1, 1, 0], // 깜빡이며 나타났다가 사라짐
-        x: [-100, 100, 100, 100, 100], // 오른쪽으로 비행
+        x: ['-60%', '60%', '60%', '60%', '60%'], // 컨테이너 안에서만 비행
         rotate: -15,
         transition: {
             duration: 2.0, // 2초 동안
@@ -71,8 +71,7 @@ const sendingVariants = {
 };
 
 export default function SignupSuccessPage() {
-    // === 2. useNavigate hook 호출 제거 ===
-    // const navigate = useNavigate();
+    const navigate = useNavigate();
     const [status, setStatus] = useState('sending'); // 'sending', 'sent'
 
     useEffect(() => {
@@ -84,44 +83,26 @@ export default function SignupSuccessPage() {
     }, []);
 
     const goToMyPage = () => {
-        // AuthPage에서 사용하던 'rewards'나 'my-page' 등 실제 마이페이지 경로로 수정하세요.
-
-        // === 3. navigate() 대신 window.location.href 사용 ===
-        // navigate('/rewards');
-        // 'useNavigate' hook이 <Router> 컨텍스트 외부에서 호출되어 오류가 발생했습니다.
-        // preivew 환경의 한계로 보이므로, 임시로 window.location.href를 사용해 이동을 시뮬레이션합니다.
-        // 실제 애플리케이션에서는 react-router-dom의 Link 컴포넌트나 useNavigate를 사용하는 것이 올바른 방법입니다.
-        console.log("Navigating to /rewards ...");
-        window.location.href = '/rewards';
+        navigate('/rewards');
     };
 
     // AuthPage의 레이아웃 클래스를 재사용하여 일관성 유지
     return (
-        <div className="auth">
+        <div className="auth signup-success">
             <motion.section
-                className="auth__form" // AuthPage와 동일한 카드 스타일 재사용
+                className="auth__form signup-success__card" // AuthPage와 동일한 카드 스타일 재사용
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.5 }}
-                // CSS에서 .auth__form에 min-height가 설정되어 있다고 가정합니다.
-                // 없다면, 레이아웃을 위해 인라인 스타일 추가
-                style={{ minHeight: '350px', display: 'flex', justifyContent: 'center', alignItems: 'center' }}
             >
                 {/* AnimatePresence를 사용하여 'sending'과 'sent' 상태가
                   부드럽게 전환되도록 합니다.
                 */}
                 <AnimatePresence mode="wait">
-                    {status === 'sending' ? (
+                        {status === 'sending' ? (
                         <motion.div
                             key="sending"
-                            // CSS 클래스나 인라인 스타일로 내부 정렬
-                            style={{
-                                textAlign: 'center',
-                                display: 'flex',
-                                flexDirection: 'column',
-                                alignItems: 'center',
-                                width: '100%'
-                            }}
+                                className="signup-success__stage"
                             variants={sendingVariants}
                             initial="hidden"
                             animate="visible"
@@ -133,15 +114,9 @@ export default function SignupSuccessPage() {
                             </h2>
                         </motion.div>
                     ) : (
-                        <motion.div
+                            <motion.div
                             key="sent"
-                            style={{
-                                textAlign: 'center',
-                                display: 'flex',
-                                flexDirection: 'column',
-                                alignItems: 'center',
-                                width: '100%'
-                            }}
+                                className="signup-success__stage"
                             variants={iconVariants}
                             initial="hidden"
                             animate="visible"
@@ -154,6 +129,7 @@ export default function SignupSuccessPage() {
                                 가입하신 이메일(및 카카오톡)을 확인해주세요.
                             </p>
                             <button
+                                type="button"
                                 onClick={goToMyPage}
                                 className="cta-button cta-button--primary" // AuthPage와 동일한 버튼 스타일 재사용
                             >

--- a/src/styles/pages/SignupSuccess.css
+++ b/src/styles/pages/SignupSuccess.css
@@ -1,0 +1,48 @@
+ .signup-success {
+     width: 100%;
+     padding: 3rem 1.25rem 4.6rem;
+     overflow-x: hidden;
+ }
+
+ .signup-success__card {
+     min-height: clamp(320px, 55vw, 420px);
+     display: flex;
+     justify-content: center;
+     align-items: center;
+     padding: clamp(2rem, 5vw, 2.6rem);
+     overflow: hidden;
+ }
+
+ .signup-success__stage {
+     width: 100%;
+     display: flex;
+     flex-direction: column;
+     align-items: center;
+     text-align: center;
+     gap: 1rem;
+ }
+
+ .signup-success__stage svg {
+     width: clamp(52px, 15vw, 76px);
+     height: clamp(52px, 15vw, 76px);
+ }
+
+ .signup-success__stage h2 {
+     margin: 0;
+ }
+
+ .signup-success__stage p {
+     margin: 0.5rem 0 1.5rem;
+ }
+
+ @media (min-width: 768px) {
+     .signup-success {
+         padding: 3rem 0 4.6rem;
+     }
+ }
+
+ @media (max-width: 480px) {
+     .signup-success__card {
+         min-height: 300px;
+     }
+ }


### PR DESCRIPTION
Prevents mobile overflow on `SignupSuccessPage` during paper plane animation and routes "마이페이지로 가기" button to `/rewards` via `useNavigate`.

The previous implementation used `window.location.href` for navigation as a workaround for a perceived preview environment limitation, but `useNavigate` is the correct React Router approach. Mobile overflow was resolved by adjusting Framer Motion `x` translation values to percentages and adding `overflow: hidden` to the card container.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb07237c-5004-4ed3-9062-8e082141dbda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fb07237c-5004-4ed3-9062-8e082141dbda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

